### PR TITLE
Fix inconsistency with Obsidian Tree Axe name

### DIFF
--- a/src/main/resources/assets/easy_emerald/lang/en_us.json
+++ b/src/main/resources/assets/easy_emerald/lang/en_us.json
@@ -48,7 +48,7 @@
    "item.easy_emerald.obsidian_excavator": "Obsidian Excavator",
    "item.easy_emerald.obsidian_hammer": "Obsidian Hammer",
    "item.easy_emerald.obsidian_paxel": "Obsidian Paxel",
-   "item.easy_emerald.obsidian_treeaxe": "Obsidian TreeAxe",
+   "item.easy_emerald.obsidian_treeaxe": "Obsidian Tree Axe",
    
    "item.easy_emerald.obsidian_head": "Obsidian Helmet",
    "item.easy_emerald.obsidian_body": "Obsidian Chestplate",


### PR DESCRIPTION
Added a space to match the other axes names